### PR TITLE
fix: use original direction when doing dir update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snakesss"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 repository = "https://github.com/Rqnsom/snakesss"
 description = "The classic (2-player) snake game"

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -59,6 +59,11 @@ pub struct Snake {
     pub body: LinkedList<Pos>,
     dir: Direction,
     color: Color,
+
+    /// Previous direction must be kept, because keyboard event loop might
+    /// handle multiple 'change direction' events, and all of those must be
+    /// compared with the original previous direction.
+    prev_dir: Direction,
 }
 
 impl Snake {
@@ -74,15 +79,22 @@ impl Snake {
             ),
             dir,
             color,
+            prev_dir: dir,
         }
     }
 
     pub fn set_direcion(&mut self, direction: Direction) {
         self.dir = match direction {
-            Direction::Down if self.dir != Direction::Up => Direction::Down,
-            Direction::Up if self.dir != Direction::Down => Direction::Up,
-            Direction::Left if self.dir != Direction::Right => Direction::Left,
-            Direction::Right if self.dir != Direction::Left => Direction::Right,
+            Direction::Down if self.prev_dir != Direction::Up => {
+                Direction::Down
+            }
+            Direction::Up if self.prev_dir != Direction::Down => Direction::Up,
+            Direction::Left if self.prev_dir != Direction::Right => {
+                Direction::Left
+            }
+            Direction::Right if self.prev_dir != Direction::Left => {
+                Direction::Right
+            }
             _ => self.dir,
         };
     }
@@ -180,6 +192,8 @@ impl Snake {
                 };
             }
         }
+
+        self.prev_dir = self.dir;
     }
 }
 


### PR DESCRIPTION
I dreamt this.
So, the keyboard event loop changes the direction,
and it can handle multiple keyboard press events between two update()
calls,
but the "new direction" we are trying to set must be compared
with the original direction.

These two subsequent calls in event_loop should not actually succeed
in updating the direction:
    // Let's say current direction is `Up`
    event_loop {
        // Okay, that's fine
        snake.set_direction(`Left`);
        // But, now this would make snake turn around for 180!
        snake.set_direction(`Down`);
    }

    update_loop { .. }

With this fix, that behaviour is not possible.